### PR TITLE
Add npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,14 @@
     "systemjs": "^0.19.3"
   },
   "devDependencies": {
-    "tsd": "^0.6.5"
+    "tsd": "^0.6.5",
+    "typescript": "^1.6.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "tsd install"
+    "postinstall": "tsd install",
+    "build": "tsc -p .",
+    "watch": "tsc -p . -w"
   },
   "keywords": [
     "TypeScript",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,12 @@
     "socket.io-client": "^1.3.7",
     "systemjs": "^0.19.3"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "tsd": "^0.6.5"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "tsd install"
   },
   "keywords": [
     "TypeScript",


### PR DESCRIPTION
3f7bdf2: you can write `pre[script]` and `post[script]` hooks that run before/after `[script]`, in this case the built-in `install`˙script. so let's run `tsd install` after `npm install` automatically :wink: 

7208dcc: commands are hard to remember, i'm usually creating simple npm scripts for running them (now you can build the project with `npm run build`). btw right now the build fails for me, not sure why, i'm getting like a billion error messages.
